### PR TITLE
Changes required to compile the dgmare-handover branch

### DIFF
--- a/administration/pom.xml
+++ b/administration/pom.xml
@@ -55,7 +55,7 @@
 			</dependency>
 			<dependency>
 				<groupId>eu.europa.ec.mare.usm</groupId>
-				<artifactId>jwt-handler-impl</artifactId>
+				<artifactId>jwt-handler-api</artifactId>
 				<version>2.1.12-SNAPSHOT</version>
 			</dependency>
 		</dependencies>

--- a/administration/rest/pom.xml
+++ b/administration/rest/pom.xml
@@ -348,7 +348,8 @@
 		</dependency>
 		<dependency>
 			<groupId>eu.europa.ec.mare.usm</groupId>
-			<artifactId>jwt-handler-impl</artifactId>
+			<artifactId>jwt-handler-api</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>


### PR DESCRIPTION
This change was actually required to deploy this locally. I think however that it makes more sense to depend on the API instead of the implementation.